### PR TITLE
Internal library gitignores

### DIFF
--- a/src/extlib/src/SDL2-2.0.1/.gitignore
+++ b/src/extlib/src/SDL2-2.0.1/.gitignore
@@ -1,0 +1,10 @@
+/Makefile
+/Makefile.rules
+/SDL2.spec
+/build/
+/config.log
+/config.status
+/libtool
+/sdl2-config
+/sdl2.pc
+/include/SDL_config.h

--- a/src/extlib/src/SDL2_image-2.0.0/.gitignore
+++ b/src/extlib/src/SDL2_image-2.0.0/.gitignore
@@ -1,0 +1,10 @@
+/.deps
+/.libs
+/*.lo
+/Makefile
+/libtool
+/sdl2_image.pc
+/config.log
+/config.status
+/libSDL2_image.la
+/showimage

--- a/src/extlib/src/SDL2_mixer-2.0.0/.gitignore
+++ b/src/extlib/src/SDL2_mixer-2.0.0/.gitignore
@@ -1,0 +1,6 @@
+/Makefile
+/SDL2_mixer.pc
+/build
+/config.log
+/config.status
+/libtool

--- a/src/extlib/src/smpeg-2.0.0/.gitignore
+++ b/src/extlib/src/smpeg-2.0.0/.gitignore
@@ -1,0 +1,16 @@
+/.deps
+/.libs
+/*.lo
+/Makefile
+/Makefile.in
+/aclocal.m4
+/autom4te.cache
+/compile
+/config.log
+/config.status
+/configure
+/libsmpeg2.la
+/libtool
+/plaympeg
+/smpeg2-config
+/smpeg2.spec


### PR DESCRIPTION
Just some gitignores, so that when we built our internal libraries, we ignore the files they autobuild.

I limited these gitignore adds to the actual library folders themselves. My other PR #30 has some more general ignores for the primary repo gitignore.
