### PR TITLE
Mouse clicks

### DIFF
--- a/src/PonscripterLabel.h
+++ b/src/PonscripterLabel.h
@@ -483,6 +483,7 @@ private:
 
     struct ButtonState {
         int x, y, button;
+        int down_x, down_y;
         bool down_flag;
         bool has_moved;
         ButtonState() { button = 0; down_flag = false; has_moved=false; }


### PR DESCRIPTION
This branch makes clicks have to be "non-moving" and works around a few windows bugs dealing with clicks triggering on window-management events.
