### PR TITLE
Fix framerate issues by reworking rerender event

### DIFF
--- a/src/PonscripterLabel.h
+++ b/src/PonscripterLabel.h
@@ -406,8 +406,6 @@ private:
     long autoclick_time;
     long remaining_time;
 
-    SDL_mutex *rerender_event_lock;
-
     bool saveon_flag;
     bool internal_saveon_flag; // to saveoff at the head of text
     int  yesno_caller;


### PR DESCRIPTION
Before the rerender was triggered via a timer. The timer has
enough overhead that the framerate rarely reached 60.

This commit switches to using the naive solution of delaying in
the event loop (what the timer tried to avoid), but first ensures
that there are no events immediately available for processing.
