### PR TITLE
Enable retina support

### DIFF
--- a/src/PonscripterLabel.cpp
+++ b/src/PonscripterLabel.cpp
@@ -462,7 +462,7 @@ void PonscripterLabel::initSDL()
         SDL_WINDOWPOS_UNDEFINED,
         SDL_WINDOWPOS_UNDEFINED,
         dispW, dispH,
-        (fullscreen_mode ? fullscreen_flags : 0) | SDL_WINDOW_RESIZABLE);
+        (fullscreen_mode ? fullscreen_flags : 0) | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
 
     /* end chronotrig */
 

--- a/src/extlib/src/SDL2-2.0.3/src/render/SDL_render.c
+++ b/src/extlib/src/SDL2-2.0.3/src/render/SDL_render.c
@@ -156,28 +156,28 @@ SDL_RendererEventWatch(void *userdata, SDL_Event *event)
         }
     } else if (event->type == SDL_MOUSEMOTION) {
         if (renderer->logical_w) {
-            event->motion.x -= renderer->viewport.x;
-            event->motion.y -= renderer->viewport.y;
-            event->motion.x = (int)(event->motion.x / renderer->scale.x);
-            event->motion.y = (int)(event->motion.y / renderer->scale.y);
+            event->motion.x -= (renderer->viewport.x * renderer->dpi_scale.x);
+            event->motion.y -= (renderer->viewport.y * renderer->dpi_scale.y);
+            event->motion.x = (int)(event->motion.x / (renderer->scale.x * renderer->dpi_scale.x));
+            event->motion.y = (int)(event->motion.y / (renderer->scale.y * renderer->dpi_scale.y));
             if (event->motion.xrel > 0) {
-                event->motion.xrel = SDL_max(1, (int)(event->motion.xrel / renderer->scale.x));
+                event->motion.xrel = SDL_max(1, (int)(event->motion.xrel / (renderer->scale.x * renderer->dpi_scale.x)));
             } else if (event->motion.xrel < 0) {
-                event->motion.xrel = SDL_min(-1, (int)(event->motion.xrel / renderer->scale.x));
+                event->motion.xrel = SDL_min(-1, (int)(event->motion.xrel / (renderer->scale.x * renderer->dpi_scale.x)));
             }
             if (event->motion.yrel > 0) {
-                event->motion.yrel = SDL_max(1, (int)(event->motion.yrel / renderer->scale.y));
+                event->motion.yrel = SDL_max(1, (int)(event->motion.yrel / (renderer->scale.y * renderer->dpi_scale.y)));
             } else if (event->motion.yrel < 0) {
-                event->motion.yrel = SDL_min(-1, (int)(event->motion.yrel / renderer->scale.y));
+                event->motion.yrel = SDL_min(-1, (int)(event->motion.yrel / (renderer->scale.y * renderer->dpi_scale.y)));
             }
         }
     } else if (event->type == SDL_MOUSEBUTTONDOWN ||
                event->type == SDL_MOUSEBUTTONUP) {
         if (renderer->logical_w) {
-            event->button.x -= renderer->viewport.x;
-            event->button.y -= renderer->viewport.y;
-            event->button.x = (int)(event->button.x / renderer->scale.x);
-            event->button.y = (int)(event->button.y / renderer->scale.y);
+            event->button.x -= (renderer->viewport.x * renderer->dpi_scale.x);
+            event->button.y -= (renderer->viewport.y * renderer->dpi_scale.y);
+            event->button.x = (int)(event->motion.x / (renderer->scale.x * renderer->dpi_scale.x));
+            event->button.y = (int)(event->motion.y / (renderer->scale.y * renderer->dpi_scale.y));
         }
     }
     return 0;
@@ -277,6 +277,18 @@ SDL_CreateRenderer(SDL_Window * window, int index, Uint32 flags)
         renderer->window = window;
         renderer->scale.x = 1.0f;
         renderer->scale.y = 1.0f;
+        renderer->dpi_scale.x = 1.0f;
+        renderer->dpi_scale.y = 1.0f;
+
+        if (window && renderer->GetOutputSize) {
+            int window_w, window_h;
+            int output_w, output_h;
+            if (renderer->GetOutputSize(renderer, &output_w, &output_h) == 0) {
+                SDL_GetWindowSize(renderer->window, &window_w, &window_h);
+                renderer->dpi_scale.x = (float)window_w / output_w;
+                renderer->dpi_scale.y = (float)window_h / output_h;
+            }
+        }
 
         if (SDL_GetWindowFlags(window) & (SDL_WINDOW_HIDDEN|SDL_WINDOW_MINIMIZED)) {
             renderer->hidden = SDL_TRUE;

--- a/src/extlib/src/SDL2-2.0.3/src/render/SDL_sysrender.h
+++ b/src/extlib/src/SDL2-2.0.3/src/render/SDL_sysrender.h
@@ -147,6 +147,9 @@ struct SDL_Renderer
     SDL_FPoint scale;
     SDL_FPoint scale_backup;
 
+    /* The pixel to point coordinate scale */
+    SDL_FPoint dpi_scale;
+
     /* The list of textures */
     SDL_Texture *textures;
     SDL_Texture *target;


### PR DESCRIPTION
Tested with Umineko Question Arcs on macOS 10.14, mouse targeting in the main menu does still work.  Not sure what other things it could break though.

Looks very nice, no more blurriness