### PR TITLE
Fix sdl2 compile on systems with gnu sed

### DIFF
--- a/src/Makefile.extlibs
+++ b/src/Makefile.extlibs
@@ -66,7 +66,8 @@ $(EB)/sdl2-config: $(SDLSRC)/Makefile
 	@ # We only make a static lib which means things using pkg-config will get it even if they think they're linking to a dynamic lib, breaking their ldflags
 	@ # Fix this by replacing `Libs: $libs\nLibs.static $staticonly` with `Libs: $libs $staticonly` in the pc file
 	@ # Note: This assumes Libs.private immediately follows Libs if it exists, which seems to be the case in most pc files that have it but isn't actually a requirement.
-	@sed -i '' -e ':a' -e 'N' -e '$$!ba' -e 's/\nLibs.private: //g' $(EL)/pkgconfig/sdl2.pc
+	@sed -e ':a' -e 'N' -e '$$!ba' -e 's/\nLibs.private: / /g' $(EL)/pkgconfig/sdl2.pc > $(EL)/pkgconfig/sdl2.pc.new
+	@mv $(EL)/pkgconfig/sdl2.pc.new $(EL)/pkgconfig/sdl2.pc
 
 #-- SDL_image -----------------------------------------------------------------
 


### PR DESCRIPTION
And I thought I unbroke everything...
Looks like my use of sed in the SDL build only worked with bsd sed, and my linux and windows builds didn't build internal sdl because the internal sdl doesn't work very well on those systems

This should unbreak the build for anyone who can use the internal sdl2 and also has gnu sed