### PR TITLE
Unbreak build on BSDs and Solaris after relative saves

### DIFF
--- a/src/PonscripterLabel.cpp
+++ b/src/PonscripterLabel.cpp
@@ -65,7 +65,7 @@ typedef HRESULT (WINAPI * GETFOLDERPATH)(HWND, int, HANDLE, DWORD, LPTSTR);
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <linux/limits.h>
+#include <limits.h>
 #include <pwd.h>
 #endif
 


### PR DESCRIPTION
Regressed by e5138a99a1ba. From [error log](https://github.com/sekaiproject/ponscripter-fork/files/6982259/ponscripter-sekai-0.0.6.162.log):
```c
c++ -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -c  -DUSE_X86_GFX -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -I/usr/local/include/SDL2 -I/usr/local/include -D_REENTRANT -D_THREAD_SAFE -I/usr/local/include -I/usr/local/include/smpeg2 -I/usr/local/include/SDL2 -I/usr/local/include -D_REENTRANT -D_THREAD_SAFE -I/usr/local/include/freetype2 -I/usr/local/include/libpng16  -DLINUX -DUSE_OGG_VORBIS -DCONST_ICONV  -DENABLE_JOYSTICK PonscripterLabel.cpp
PonscripterLabel.cpp:68:10: fatal error: 'linux/limits.h' file not found
#include <linux/limits.h>
         ^~~~~~~~~~~~~~~~
1 error generated.
gmake[2]: *** [Makefile.ponscripter:61: PonscripterLabel.o] Error 1
```

`-DLINUX` is passed on FreeBSD, NetBSD, OpenBSD, Solaris, not just Linux.
https://github.com/sekaiproject/ponscripter-fork/blob/4f887b86be6dc3e232a20a0527d6264924641bdb/configure#L294-L298
https://github.com/sekaiproject/ponscripter-fork/blob/4f887b86be6dc3e232a20a0527d6264924641bdb/configure#L986-L1015
